### PR TITLE
Readd test DisplayQuestion, fix tests schedule

### DIFF
--- a/app/src/androidTest/java/ch/epfl/sweng/studyup/DisplayQuestionActivityTest/DisplayQuestionActivityLuluTest.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/studyup/DisplayQuestionActivityTest/DisplayQuestionActivityLuluTest.java
@@ -1,0 +1,91 @@
+package ch.epfl.sweng.studyup.DisplayQuestionActivityTest;
+
+import android.content.Intent;
+import android.support.test.rule.ActivityTestRule;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+import ch.epfl.sweng.studyup.R;
+import ch.epfl.sweng.studyup.player.Player;
+import ch.epfl.sweng.studyup.questions.DisplayQuestionActivity;
+import ch.epfl.sweng.studyup.questions.Question;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static ch.epfl.sweng.studyup.questions.DisplayQuestionActivity.DISPLAY_QUESTION_ANSWER;
+import static ch.epfl.sweng.studyup.questions.DisplayQuestionActivity.DISPLAY_QUESTION_DURATION;
+import static ch.epfl.sweng.studyup.questions.DisplayQuestionActivity.DISPLAY_QUESTION_ID;
+import static ch.epfl.sweng.studyup.questions.DisplayQuestionActivity.DISPLAY_QUESTION_LANG;
+import static ch.epfl.sweng.studyup.questions.DisplayQuestionActivity.DISPLAY_QUESTION_TITLE;
+import static ch.epfl.sweng.studyup.questions.DisplayQuestionActivity.DISPLAY_QUESTION_TRUE_FALSE;
+import static ch.epfl.sweng.studyup.utils.Constants.Course.SWENG;
+import static ch.epfl.sweng.studyup.utils.Constants.Role.student;
+import static ch.epfl.sweng.studyup.utils.Constants.XP_GAINED_WITH_QUESTION;
+import static ch.epfl.sweng.studyup.utils.GlobalAccessVariables.MOCK_ENABLED;
+import static org.junit.Assert.assertEquals;
+
+public class DisplayQuestionActivityLuluTest {
+    private String id = "ID Test display question";
+    private Question q = new Question(id, "Test display question Lulu", false, 0, SWENG.name(), "en");
+
+    @Rule
+    public final ActivityTestRule<DisplayQuestionActivity> mActivityRule =
+            new ActivityTestRule<>(DisplayQuestionActivity.class, true, false);
+
+    @BeforeClass
+    public static void enableMock(){
+        MOCK_ENABLED = true;
+    }
+
+    @AfterClass
+    public static void disableMock(){
+        MOCK_ENABLED = false;
+    }
+
+    @Before
+    public void resetPlayer(){
+        Player.get().resetPlayer();
+        Player.get().setRole(student);
+
+        Intent intent = new Intent();
+        intent.putExtra(DISPLAY_QUESTION_TITLE, q.getTitle());
+        intent.putExtra(DISPLAY_QUESTION_ID, q.getQuestionId());
+        intent.putExtra(DISPLAY_QUESTION_TRUE_FALSE, Boolean.toString(q.isTrueFalse()));
+        intent.putExtra(DISPLAY_QUESTION_ANSWER, Integer.toString(q.getAnswer()));
+        intent.putExtra(DISPLAY_QUESTION_LANG, q.getLang());
+        intent.putExtra(DISPLAY_QUESTION_DURATION, Long.toString(q.getDuration()));
+
+        Player.get().addClickedInstant(id, System.currentTimeMillis());
+
+        mActivityRule.launchActivity(intent);
+    }
+
+    @Test
+    public void correctAnswerQuestionTest(){
+        int exp = Player.get().getExperience();
+
+        onView(withId(R.id.answer1)).perform(click());
+        onView(withId(R.id.answer2)).perform(click());
+        onView(withId(R.id.answer3)).perform(click());
+        onView(withId(R.id.answer4)).perform(click());
+        onView(withId(R.id.answer1)).perform(click());
+        onView(withId(R.id.answer_button)).perform(click());
+
+        assertEquals(exp + XP_GAINED_WITH_QUESTION, Player.get().getExperience());
+    }
+
+    @Test
+    public void wrongAnswerQuestionTest(){
+        int exp = Player.get().getExperience();
+
+        onView(withId(R.id.answer2)).perform(click());
+        onView(withId(R.id.answer_button)).perform(click());
+
+        assertEquals(exp, Player.get().getExperience());
+    }
+}

--- a/app/src/androidTest/java/ch/epfl/sweng/studyup/ScheduleTest/ScheduleActivityStudentTest.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/studyup/ScheduleTest/ScheduleActivityStudentTest.java
@@ -69,8 +69,9 @@ public class ScheduleActivityStudentTest {
     public void studentScheduleTest(){
         Player.get().setRole(Constants.Role.student);
         mActivityRule.launchActivity(new Intent());
+        Utils.waitAndTag(1000, "ScheduleActivityStudentTest");
 
-        assertEquals(0, mActivityRule.getActivity().getWeekViewEvents().size());
+        int previousSize = mActivityRule.getActivity().getWeekViewEvents().size();
 
         Display display = mActivityRule.getActivity().getWindowManager().getDefaultDisplay();
         Point size = new Point();
@@ -80,13 +81,14 @@ public class ScheduleActivityStudentTest {
 
         onView(withId(R.id.weekView)).perform(clickXY(width - 8, height/2));
         Utils.waitAndTag(1000, "ScheduleActivityStudentTest");
-        assertEquals(0, mActivityRule.getActivity().getWeekViewEvents().size());
+        assertEquals(previousSize, mActivityRule.getActivity().getWeekViewEvents().size());
     }
 
     @Test
     public void updateScheduleTest(){
+        Player.get().setRole(Constants.Role.student);
         mActivityRule.launchActivity(new Intent());
-        assertEquals(0, mActivityRule.getActivity().getWeekViewEvents().size());
+        Utils.waitAndTag(1000, "ScheduleActivityStudentTest");
 
         final List<WeekViewEvent> events = new ArrayList<>();
 

--- a/app/src/androidTest/java/ch/epfl/sweng/studyup/ScheduleTest/ScheduleActivityTeacherTest.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/studyup/ScheduleTest/ScheduleActivityTeacherTest.java
@@ -184,7 +184,7 @@ public class ScheduleActivityTeacherTest {
 
     @Test
     public void backButtonTest() {
-        mActivityRule.launchActivity(new Intent());
+        mActivityRule.launchActivity(new Intent().putExtra(COURSE_NAME_INTENT_SCHEDULE, Constants.Course.FakeCourse.name()));
         onView(withId(R.id.back_button)).perform(click());
         TestCase.assertTrue(mActivityRule.getActivity().isFinishing());
     }

--- a/app/src/androidTest/java/ch/epfl/sweng/studyup/ScheduleTest/ScheduleActivityTeacherTest.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/studyup/ScheduleTest/ScheduleActivityTeacherTest.java
@@ -82,8 +82,15 @@ public class ScheduleActivityTeacherTest {
     @Test
     public void addEventAndRemoveEventTest() throws UiObjectNotFoundException {
         mActivityRule.launchActivity(new Intent().putExtra(COURSE_NAME_INTENT_SCHEDULE, Constants.Course.FakeCourse.name()));
+        waitAndTag(1000, "ScheduleActivityTeacherTest");
 
-        assertEquals(0, mActivityRule.getActivity().getWeekViewEvents().size());
+        mActivityRule.getActivity().runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                mActivityRule.getActivity().updateSchedule(new ArrayList<WeekViewEvent>());
+            }
+        });
+        waitAndTag(1000, "ScheduleActivityTeacherTest");
 
         Display display = mActivityRule.getActivity().getWindowManager().getDefaultDisplay();
         Point size = new Point();
@@ -119,13 +126,13 @@ public class ScheduleActivityTeacherTest {
                 mActivityRule.getActivity().onSaveButtonClick(null);
             }
         });
-        waitAndTag(150, "Waiting for the main thread to click");
+        waitAndTag(1000, "Waiting for the main thread to click");
     }
 
     @Test
     public void updateScheduleTest() {
         mActivityRule.launchActivity(new Intent().putExtra(COURSE_NAME_INTENT_SCHEDULE, Constants.Course.FakeCourse.name()));
-        assertEquals(0, mActivityRule.getActivity().getWeekViewEvents().size());
+        waitAndTag(1000, "ScheduleActivityTeacherTest");
 
         final List<WeekViewEvent> events = new ArrayList<>();
 

--- a/app/src/main/java/ch/epfl/sweng/studyup/player/Player.java
+++ b/app/src/main/java/ch/epfl/sweng/studyup/player/Player.java
@@ -129,6 +129,7 @@ public class Player implements SpecialQuestObservable {
         coursesEnrolled.add(Course.SWENG);
         coursesTeached = new ArrayList<>();
         scheduleStudent = new ArrayList<>();
+        clickedInstants = new HashMap<>();
     }
 
     /**

--- a/app/src/main/java/ch/epfl/sweng/studyup/player/Player.java
+++ b/app/src/main/java/ch/epfl/sweng/studyup/player/Player.java
@@ -216,7 +216,7 @@ public class Player implements SpecialQuestObservable {
     public boolean isSuperUser() {
         return SUPER_USERS.contains(getSciperNum());
     }
-    public Map<String, Long> getClickedInstants() {return Collections.unmodifiableMap(new HashMap<>(clickedInstants)); }
+    public Map<String, Long> getClickedInstants() {return Collections.unmodifiableMap(clickedInstants); }
 
     // Setters
     public void setSciperNum(String sciperNum) {

--- a/app/src/main/java/ch/epfl/sweng/studyup/player/ScheduleActivityStudent.java
+++ b/app/src/main/java/ch/epfl/sweng/studyup/player/ScheduleActivityStudent.java
@@ -117,8 +117,8 @@ public class ScheduleActivityStudent extends NavigationStudent {
     public void updateSchedule(List<WeekViewEvent> events){
         if(Build.VERSION.SDK_INT > Build.VERSION_CODES.O_MR1) return;
         weekViewEvents.clear();
-        weekViewEvents.addAll(events);
-        id += events.size();
+        weekViewEvents = new ArrayList<>(events);
+        id = events.size();
         weekView.notifyDatasetChanged();
     }
 

--- a/app/src/main/java/ch/epfl/sweng/studyup/questions/AddOrEditQuestionActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/studyup/questions/AddOrEditQuestionActivity.java
@@ -127,8 +127,7 @@ public class AddOrEditQuestionActivity extends NavigationStudent {
         return chosenCourse;
     }
     /**
-     * Function called when the user wants to choose an image in gallery
-     *
+     * Function called when the user wants to choose an image in gallery    
      * @param current the current view
      */
     public void performFileSearch(View current) {

--- a/app/src/main/java/ch/epfl/sweng/studyup/questions/DisplayQuestionActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/studyup/questions/DisplayQuestionActivity.java
@@ -7,17 +7,14 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-import android.graphics.Color;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.SystemClock;
 import android.support.annotation.NonNull;
 import android.support.v4.app.NotificationCompat;
-import android.support.v7.widget.Toolbar;
 import android.util.Log;
 import android.view.View;
-import android.widget.Button;
 import android.widget.CompoundButton;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
@@ -34,7 +31,6 @@ import com.google.firebase.storage.StorageReference;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
@@ -47,7 +43,6 @@ import ch.epfl.sweng.studyup.firebase.FileStorage;
 import ch.epfl.sweng.studyup.items.Items;
 import ch.epfl.sweng.studyup.player.Player;
 import ch.epfl.sweng.studyup.player.QuestsActivityStudent;
-import ch.epfl.sweng.studyup.specialQuest.SpecialQuestType;
 import ch.epfl.sweng.studyup.utils.Constants.Course;
 import ch.epfl.sweng.studyup.utils.Constants.SpecialQuestUpdateFlag;
 import ch.epfl.sweng.studyup.utils.RefreshContext;
@@ -76,7 +71,6 @@ public class DisplayQuestionActivity extends RefreshContext {
     public static final String CHANNEL_ID = "studyup_question_timeout";
 
     private Question displayQuestion;
-    private Player player;
 
     private RadioGroup answerGroupTOP;
     private RadioGroup answerGroupBOT;
@@ -186,11 +180,11 @@ public class DisplayQuestionActivity extends RefreshContext {
     private void handleTimedQuestion(Question displayQuestion) {
         String questionId = displayQuestion.getQuestionId();
         TextView time_left = findViewById(R.id.time_left); ImageView alarm = findViewById(R.id.alarmImage);
-        long now = System.currentTimeMillis(), clickedInstant = player.getClickedInstants().get(questionId);
+        long now = System.currentTimeMillis(), clickedInstant = Player.get().getClickedInstants().get(questionId);
 
-        if (displayQuestion.getDuration() != 0 && !player.getClickedInstants().containsKey(questionId)) {
+        if (displayQuestion.getDuration() != 0 && !Player.get().getClickedInstants().containsKey(questionId)) {
             //The question has not been clicked on yet
-            player.addClickedInstant(questionId, System.currentTimeMillis());
+            Player.get().addClickedInstant(questionId, System.currentTimeMillis());
             setupNotificationManager();
         } else if (displayQuestion.getDuration() == 0) {
             //There is no time constraint

--- a/app/src/main/java/ch/epfl/sweng/studyup/questions/DisplayQuestionActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/studyup/questions/DisplayQuestionActivity.java
@@ -180,7 +180,7 @@ public class DisplayQuestionActivity extends RefreshContext {
     private void handleTimedQuestion(Question displayQuestion) {
         String questionId = displayQuestion.getQuestionId();
         TextView time_left = findViewById(R.id.time_left); ImageView alarm = findViewById(R.id.alarmImage);
-        long now = System.currentTimeMillis(), clickedInstant = Player.get().getClickedInstants().get(questionId);
+        long now = System.currentTimeMillis();
 
         if (displayQuestion.getDuration() != 0 && !Player.get().getClickedInstants().containsKey(questionId)) {
             //The question has not been clicked on yet
@@ -189,15 +189,19 @@ public class DisplayQuestionActivity extends RefreshContext {
         } else if (displayQuestion.getDuration() == 0) {
             //There is no time constraint
             alarm.setImageAlpha(0); time_left.setText("");
-        } else if (now > clickedInstant + displayQuestion.getDuration()) {
-            //too late, the player cannot answer anymore
-            tooLate = true; time_left.setText(getString(R.string.elapsed_time));
         } else {
-            //display remaining time
-            int timeLeft = (int) ((displayQuestion.getDuration() - (now -  clickedInstant))/(double)(1000 * 60));
-            String displayedText = getString(R.string.remaining_time)+" "+timeLeft+"min";
-            time_left.setText(displayedText);
-            if(timeLeft < 0){ time_left.setText(getString(R.string.elapsed_time)); }
+            long clickedInstant = Player.get().getClickedInstants().get(questionId);
+            if (now > clickedInstant + displayQuestion.getDuration()) {
+                //too late, the player cannot answer anymore
+                tooLate = true;
+                time_left.setText(getString(R.string.elapsed_time));
+            } else {
+                //display remaining time
+                int timeLeft = (int) ((displayQuestion.getDuration() - (now -  clickedInstant))/(double)(1000 * 60));
+                String displayedText = getString(R.string.remaining_time)+" "+timeLeft+"min";
+                time_left.setText(displayedText);
+                if(timeLeft < 0){ time_left.setText(getString(R.string.elapsed_time)); }
+            }
         }
     }
 


### PR DESCRIPTION
# Add coverage and fix tests
- This PR readds the test for DisplayQuestionActivity that disappeared somehow. So I rewrote a test for it that works with the current version of the app.
- I also fixed the Schedule tests that were failing because of events on Firebase being present.

*made by @Gorzen*